### PR TITLE
Update Supported VapourSynth Versions to R61, Improve CI build Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,34 +13,44 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        vs-version: [latest, 51, 50, 49, 48, 47, 47.2, 47.1, 46, 45.1, "45.0", 45, 44]
+        vs-version: [latest, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47.2, 46, 45.1, 44]
         include:
         - vs-version: latest
-          python-version: 3.8
+          python-version: '3.10'  # or 3.8
+        - vs-version: 60
+          python-version: '3.10'  # or 3.8
+        - vs-version: 59
+          python-version: '3.10'  # or 3.8
+        - vs-version: 58
+          python-version: '3.10'  # or 3.8
+        - vs-version: 57
+          python-version: '3.9'
+        - vs-version: 56
+          python-version: '3.9'
+        - vs-version: 55
+          python-version: '3.9'
+        - vs-version: 54
+          python-version: '3.9'
+        - vs-version: 53
+          python-version: '3.9'
+        - vs-version: 52
+          python-version: '3.8'
         - vs-version: 51
-          python-version: 3.8
+          python-version: '3.8'
         - vs-version: 50
-          python-version: 3.8
+          python-version: '3.8'
         - vs-version: 49
-          python-version: 3.8
+          python-version: '3.8'
         - vs-version: 48
-          python-version: 3.7
-        - vs-version: 47
-          python-version: 3.7
+          python-version: '3.7'
         - vs-version: 47.2
-          python-version: 3.7
-        - vs-version: 47.1
-          python-version: 3.7
+          python-version: '3.7'
         - vs-version: 46
-          python-version: 3.7
+          python-version: '3.7'
         - vs-version: 45.1
-          python-version: 3.7
-        - vs-version: 45.0
-          python-version: 3.7
-        - vs-version: 45
-          python-version: 3.7
+          python-version: '3.7'
         - vs-version: 44
-          python-version: 3.6
+          python-version: '3.6'
 
 
     steps:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Currently it is tested with these versions on Windows and Linux:
 
 | VapourSynth | Python-Version | Notes |
 | ----------- | --------- | ---- |
+| R61 | Python 3.10 and 3.8 | |
+| R60 | Python 3.10 and 3.8 | |
+| R59 | Python 3.10 and 3.8 | |
+| R58 | Python 3.10 and 3.8 | |
+| R57 | Python 3.9 | |
+| R56 | Python 3.9 | |
+| R55 | Python 3.9 | |
+| R54 | Python 3.9 | |
+| R53 | Python 3.9 | |
+| R52 | Python 3.8 | |
+| R51 | Python 3.8 | |
 | R50 | Python 3.8 | |
 | R49 | Python 3.8 | |
 | R47.2 | Python 3.7 | |

--- a/src/vs_versions.js
+++ b/src/vs_versions.js
@@ -1,10 +1,70 @@
 export const VS_ALIASES = {
-    "latest": "51",
+    "latest": "61",
     "47": "47.2",
     "45": "45.0"
 };
 
 export const VS_VERSIONS = {
+    "61": {
+        pypi_version: "61",
+        minor: "61",
+        vs_branch: "R61",
+        zimg_branch: "v3.0"
+    },
+    "60": {
+        pypi_version: "60",
+        minor: "60",
+        vs_branch: "R60",
+        zimg_branch: "v3.0"
+    },
+    "59": {
+        pypi_version: "59",
+        minor: "59",
+        vs_branch: "R59",
+        zimg_branch: "v3.0"
+    },
+    "58": {
+        pypi_version: "58",
+        minor: "58",
+        vs_branch: "R58",
+        zimg_branch: "v3.0"
+    },
+    "57": {
+        pypi_version: "57",
+        minor: "57",
+        vs_branch: "R57",
+        zimg_branch: "v3.0"
+    },
+    "56": {
+        pypi_version: "56",
+        minor: "56",
+        vs_branch: "R56",
+        zimg_branch: "v3.0"
+    },
+    "55": {
+        pypi_version: "55",
+        minor: "55",
+        vs_branch: "R55",
+        zimg_branch: "v3.0"
+    },
+    "54": {
+        pypi_version: "54",
+        minor: "54",
+        vs_branch: "R54",
+        zimg_branch: "v2.9"
+    },
+    "53": {
+        pypi_version: "53",
+        minor: "53",
+        vs_branch: "R53",
+        zimg_branch: "v2.9"
+    },
+    "52": {
+        pypi_version: "52",
+        minor: "52",
+        vs_branch: "R52",
+        zimg_branch: "v2.9"
+    },
     "51": {
         pypi_version: "51",
         minor: "51",


### PR DESCRIPTION
Tested working on Linux. Windows builds needs testing but likely works.

I removed multiple duplicate tests in the 'Run tests' GitHub Workflow. You had it testing 'latest' and the latest rXX in VS_VERSIONS which tests the same version wasting GitHub Actions minutes. You may be doing it to test if 'latest' is working but realistically it would be, and even if it wasn't the right 'latest' version, you wouldn't notice or test for that in the GitHub workflow.

You also had duplicate tests that just had a `.0` for the minor compared to no explicit minor version. That's again wasting GitHub Actions minutes. I also only tested the latest minor version of each major version (if any revision). E.g., only 47.2 for R47. This was mainly so that it wouldn't waste minutes when we know it would fail on R47.0 for Linux, making all 'Run tests' builds ultimately be marked as failed runs (giving a nice annoying email every commit). Testing each revision/minor version was also generally pointless due to the little amount of changes.